### PR TITLE
make storage size on topics more human readable

### DIFF
--- a/pages/topics/_id.vue
+++ b/pages/topics/_id.vue
@@ -36,7 +36,8 @@
         </el-table-column>
         <el-table-column
           prop="storageSize"
-          label="Storage size (bytes)">
+          label="Storage size"
+          :formatter="cellFormatBytesToBestUnit">
         </el-table-column>
       </el-table>
 
@@ -147,7 +148,7 @@
 </template>
 
 <script>
-import { cellFormatFloat, cellFormatDateSince } from '@/services/utils'
+import { cellFormatFloat, cellFormatBytesToBestUnit, cellFormatDateSince } from '@/services/utils'
 import loading from '@/components/loading'
 import breadcrumb from '@/components/breadcrumb'
 import { mapState, mapActions } from 'vuex'
@@ -215,6 +216,7 @@ export default {
 
   methods: {
     cellFormatFloat,
+    cellFormatBytesToBestUnit,
     cellFormatDateSince,
 
     async reload() {

--- a/pages/topics/index.vue
+++ b/pages/topics/index.vue
@@ -43,6 +43,11 @@
           :formatter="cellFormatFloat">
         </el-table-column>
         <el-table-column
+          prop="stats.storageSize"
+          label="Storage size"
+          :formatter="cellFormatBytesToBestUnit">
+        </el-table-column>
+        <el-table-column
           fixed="right"
           label="Actions"
           width="200">
@@ -105,7 +110,7 @@
 </template>
 
 <script>
-import { cellFormatFloat } from '@/services/utils'
+import { cellFormatFloat, cellFormatBytesToBestUnit } from '@/services/utils'
 import loading from '@/components/loading'
 import breadcrumb from '@/components/breadcrumb'
 import { mapState, mapActions } from 'vuex'
@@ -152,6 +157,7 @@ export default {
 
   methods: {
     cellFormatFloat,
+    cellFormatBytesToBestUnit,
 
     ...mapActions('context', ['setTopic', 'setTopics']),
 
@@ -240,7 +246,6 @@ export default {
           persistent: ref.topic.startsWith('persistent'), 
           stats: topicStats })
       }
-
       this.setTopics(this.topics)
 
       this.loading = false

--- a/services/utils.js
+++ b/services/utils.js
@@ -4,6 +4,20 @@ export function cellFormatFloat(row, column, cellValue, index) {
   return parseFloat(cellValue).toFixed(2)
 }
 
+export function cellFormatBytesToBestUnit(row, column, cellValue, index) {
+  const bytes = cellValue
+  const decimals = 2
+  if (bytes === 0) return '0 Bytes';
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}
+
 export function cellFormatDateSince(row, column, cellValue, index) {
   return moment(cellValue).fromNow()
 }


### PR DESCRIPTION
It's more easy to read on topic details page.

I added it on topics list too, but I'm not convinced that it's a good idea that the storage sizes listed in different units.

WDYT?