### PR TITLE
fix: Fix display when topic returns 500

### DIFF
--- a/pages/topics/index.vue
+++ b/pages/topics/index.vue
@@ -264,15 +264,23 @@ export default {
 
       this.topics = []
 
+      const topicWithStats = (ref, stats) => {
+        return {
+          cluster: ref.cluster,
+          name: ref.topic.substring(ref.topic.indexOf('://') + 3), 
+          persistent: ref.topic.startsWith('persistent'), 
+          stats: stats
+        }
+      }
+
       this.topics = await Promise.all(
         topicRefs.map(ref =>
           this.$pulsar.fetchTopicStats(ref.topic.replace(":/",""), ref.cluster)
-            .then((topicStats) => ({
-              cluster: ref.cluster,
-              name: ref.topic.substring(ref.topic.indexOf('://') + 3), 
-              persistent: ref.topic.startsWith('persistent'), 
-              stats: topicStats
-            }))
+            .then((topicStats) => topicWithStats(ref, topicStats))
+            .catch((e) => {
+              console.error(e);
+              return topicWithStats(ref, undefined);
+            })
         )
       )
 


### PR DESCRIPTION
Hi there,

When a topic returns HTTP 500, the whole page `topic` does not display because of the global `Promise.all`.

This PR fixes that, to at least display the name of the topic which is failing, and the other ones as expected.

Thank you for this useful tool!