### PR TITLE
Add some cluster management features and make the pulsar express more robust to work with large number of topics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,13 @@ ENV APP_ROOT /app
 
 RUN mkdir ${APP_ROOT}
 WORKDIR ${APP_ROOT}
+
+ADD ./package.json ${APP_ROOT}/package.json
+ADD ./package-lock.json ${APP_ROOT}/package-lock.json
+RUN npm install
+
 ADD . ${APP_ROOT}
 
-RUN npm install
 RUN npm run build
 
 EXPOSE 3000

--- a/components/navbar.vue
+++ b/components/navbar.vue
@@ -12,6 +12,9 @@
           <nuxt-link to="/brokers">Brokers</nuxt-link>
         </div>
         <div class="nav-item">
+          <nuxt-link to="/brokers">Workers</nuxt-link>
+        </div>
+        <div class="nav-item">
           <nuxt-link to="/tenants">Tenants</nuxt-link>
         </div>
         <div class="nav-item">

--- a/components/navbar.vue
+++ b/components/navbar.vue
@@ -12,7 +12,7 @@
           <nuxt-link to="/brokers">Brokers</nuxt-link>
         </div>
         <div class="nav-item">
-          <nuxt-link to="/brokers">Workers</nuxt-link>
+          <nuxt-link to="/workers">Workers</nuxt-link>
         </div>
         <div class="nav-item">
           <nuxt-link to="/tenants">Tenants</nuxt-link>

--- a/pages/clusters/index.vue
+++ b/pages/clusters/index.vue
@@ -67,6 +67,18 @@
             </el-button>
           </template>
         </el-table-column>
+        <el-table-column
+          fixed="right"
+          label="Actions">
+          <template slot-scope="scope">
+            <el-button
+              @click.native.prevent="rebalanceWorkers(scope.row)"
+              type="warning" plain round
+              size="mini">
+              Rebalance worker
+            </el-button>
+          </template>
+        </el-table-column>
       </el-table>
     </div>
     <div v-else>
@@ -198,6 +210,21 @@ export default {
       this.loading = true
       this.clusters = await this.$pulsar.fetchClusters(this.connections)
       this.loading = false
+    },
+    
+    rebalanceWorkers(cluster) {
+      this.$pulsar.rebalanceWorkers(cluster)
+        .then((resp) => {
+          this.$message({
+            message: 'Rebalanced: ' + resp
+          })
+        })
+        .catch ((err) => {
+          this.$message({
+            type: 'error',
+            message: 'Error: ' + err
+          })
+        })
     }
   },
 

--- a/pages/functions/_cluster/_tenant/_namespace/_id.vue
+++ b/pages/functions/_cluster/_tenant/_namespace/_id.vue
@@ -223,7 +223,6 @@ export default {
     
       const status = await this.$pulsar.fetchFunctionStatus(this.fullname, this.currentFunction.cluster)
       this.instances = status.instances
-      console.log(status)
     },
 
     stopAllInstances() {

--- a/pages/functions/index.vue
+++ b/pages/functions/index.vue
@@ -7,7 +7,7 @@
         :data="functions"
         style="width: 100%"
         height_="800"
-        :default-sort = "{prop: 'name', order: 'ascending'}">
+        :default-sort = "{prop: 'status.numRunning', order: 'ascending'}">
         <el-table-column
           fixed
           label="Name"
@@ -25,6 +25,19 @@
           prop="infos.runtime"
           label="Runtime"
           width="100">
+        </el-table-column>
+        <el-table-column
+          prop="status.numRunning"
+          label="Running"
+          sortable
+          width="100">
+          <template slot-scope="scope">
+            <el-tag
+                :type="scope.row.status.numRunning >= scope.row.status.numInstances ? 'success' : scope.row.status.numRunning <= 0 ? 'danger' : 'warning'"
+                disable-transitions>
+                {{scope.row.status.numRunning}}/{{scope.row.status.numInstances}}
+            </el-tag>
+          </template>
         </el-table-column>
         <el-table-column
           label="Class name">
@@ -177,10 +190,12 @@ export default {
       for (const functions of functionsByNs) {
         for (const fctName of functions.names) {
           const fctSInfos = await this.$pulsar.fetchFunction(functions.namespace + '/' + fctName, functions.cluster)
+          const fctStatus = await this.$pulsar.fetchFunctionStatus(functions.namespace + '/' + fctName, functions.cluster)
           this.functions.push({
             id: this.functions.length,
             cluster: functions.cluster,
-            infos: fctSInfos })
+            infos: fctSInfos,
+            status: fctStatus })
         }
       }
 

--- a/pages/functions/index.vue
+++ b/pages/functions/index.vue
@@ -14,9 +14,11 @@
           sortable
           width="200">
           <template slot-scope="scope">
-            <el-button type="text" @click.native.prevent="showDetails(scope.row.id)">
-              {{scope.row.infos.tenant}}/{{scope.row.infos.namespace}}/{{scope.row.infos.name}}
-            </el-button>
+            <a :href="`/functions/${scope.row.cluster.name}/${scope.row.infos.tenant}/${scope.row.infos.namespace}/${scope.row.infos.name}`">
+              <el-button type="text" @click.native.prevent="showDetails(scope.row.id)">
+                {{scope.row.infos.tenant}}/{{scope.row.infos.namespace}}/{{scope.row.infos.name}}
+              </el-button>
+            </a>
           </template>
         </el-table-column>
         <el-table-column
@@ -129,8 +131,8 @@ export default {
     },
 
     showDetails(id) {
-      this.setFunction(id)
-      this.$router.push({ path: '/functions/' + id })
+      const func = this.functions[id]
+      this.$router.push({ path: '/functions/' + func.cluster.name + '/' + func.infos.tenant + '/' + func.infos.namespace + '/' + func.infos.name })
     },
 
     async reload() {

--- a/pages/functions/index.vue
+++ b/pages/functions/index.vue
@@ -40,6 +40,32 @@
           </template>
         </el-table-column>
         <el-table-column
+          label="Read/Written">
+          <template slot-scope="scope">
+            {{scope.row.status.instances.reduce((r, d) => r + d.status.numReceived, 0)}}/{{scope.row.status.instances.reduce((r, d) => r + d.status.numSuccessfullyProcessed, 0)}}
+          </template>
+        </el-table-column>
+        <el-table-column
+          label="Restarts"
+          width="100">
+          <template slot-scope="scope">
+            {{scope.row.status.instances.reduce((r, d) => r + d.status.numRestarts, 0)}}
+          </template>
+        </el-table-column>
+        <el-table-column
+          label="Latency"
+          width="100">
+          <template slot-scope="scope">
+            {{scope.row.status.instances.reduce((r, d) => Math.round(Math.max(r, d.status.averageLatency) * 100) / 100, 0)}}
+          </template>
+        </el-table-column>
+        <el-table-column
+          label="Last invocation">
+          <template slot-scope="scope">
+            {{new Date(scope.row.status.instances.reduce((r, d) => Math.max(r, d.status.lastInvocationTime), 0)).toLocaleDateString('en-us', { month:"short", day:"numeric", hour:"numeric", minute:"numeric", second:"numeric"})}}
+          </template>
+        </el-table-column>
+        <el-table-column
           label="Class name">
           <template slot-scope="scope">
             {{shortClassName(scope.row.infos.className)}}

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -20,6 +20,18 @@
           <el-button type="text" class="big-number" @click.native.prevent="$router.push({ path: '/topics' })">{{ topics.length }}</el-button>
         </el-card>
       </el-col>
+      <el-col :span="8">
+        <el-card shadow="never">
+          <h3 class="subtitle"><img src="~/assets/brokers.png" width="32" />Workers</h3>
+          <el-button type="text" class="big-number" @click.native.prevent="$router.push({ path: '/workers' })">{{ workers.length }}</el-button>
+        </el-card>
+      </el-col>
+      <el-col :span="8">
+        <el-card shadow="never">
+          <h3 class="subtitle"><img src="~/assets/sinks.png" width="32" />Sinks</h3>
+          <el-button type="text" class="big-number" @click.native.prevent="$router.push({ path: '/sinks' })">{{ sinks.length }}</el-button>
+        </el-card>
+      </el-col>
     </el-row>
   </div>
 </template>
@@ -36,7 +48,9 @@ export default {
     return {
       clusters: [],
       brokers: [],
-      topics: []
+      topics: [],
+      workers: [],
+      sinks: []
     }
   },
 
@@ -52,6 +66,8 @@ export default {
       this.clusters = await this.$pulsar.fetchClusters(this.connections)
       this.brokers = await this.$pulsar.fetchBrokers(this.clusters)
       this.topics = await this.$pulsar.fetchTopics(this.clusters)
+      this.workers = await this.$pulsar.fetchWorkers(this.clusters)
+      this.sinks = await this.$pulsar.fetchSinks(this.clusters)
     }
   },
 

--- a/pages/sinks/_cluster/_tenant/_namespace/_id.vue
+++ b/pages/sinks/_cluster/_tenant/_namespace/_id.vue
@@ -71,9 +71,37 @@ export default {
   methods: {
     cellFormatFloat,
     cellFormatBoolean,
+    
+    ...mapActions('context', ['setSink', 'setSinks']),
 
     async reload() {
-      this.policies = await this.$pulsar.fetchSink(this.currentSink.sink, this.currentSink.cluster, this.currentSink.ns)
+      let connections = []
+
+      if (this.cluster) {
+        connections.push(this.cluster.connection)
+      }
+      else {
+        await this.$store.dispatch('connections/fetchConnections')
+        connections = this.$store.state.connections.connections
+      }
+
+      this.clusters = await this.$pulsar.fetchClusters(connections)
+      const cluster = this.clusters.find(c => c.name == this.$route.params.cluster)
+      
+      this.sinks = [
+        {
+          cluster: cluster,
+          ns: {cluster: cluster, namespace: this.$route.params.tenant + '/' + this.$route.params.namespace},
+          sink: this.$route.params.id
+        }
+      ]
+      console.log(this.sinks)
+      this.setSinks([1])
+      this.setSink(0)
+      console.log(this.sinks)
+      console.log(this.sink)
+      
+      this.policies = await this.$pulsar.fetchSink(this.currentSink.sink, cluster, this.currentSink.ns)
     }
   },
 

--- a/pages/sinks/index.vue
+++ b/pages/sinks/index.vue
@@ -13,7 +13,9 @@
           sortable
           width="250">
           <template slot-scope="scope">
-            <el-button type="text" @click.native.prevent="showDetails(scope.row.id)">{{ scope.row.sink }}</el-button>
+            <a :href="`/sinks/${scope.row.cluster.name}/${scope.row.ns.namespace}/${scope.row.sink}`">
+              <el-button type="text" @click.native.prevent="showDetails(scope.row.id)">{{ scope.row.sink }}</el-button>
+            </a>
           </template>
         </el-table-column>
         <el-table-column
@@ -106,7 +108,8 @@ export default {
 
     showDetails(id) {
       this.setSink(id)
-      this.$router.push({ path: '/sinks/' + id })
+      const sink = this.sinks[id]
+      this.$router.push({ path: '/sinks/' + sink.cluster.name + '/' + sink.ns.namespace + '/' + sink.sink })
     },
   },
 

--- a/pages/sinks/index.vue
+++ b/pages/sinks/index.vue
@@ -6,13 +6,12 @@
       <el-table
         :data="sinks"
         style="width: 100%"
-        :default-sort = "{prop: 'status.numRunning', order: 'ascending'}>
+        :default-sort = "{prop: 'status.numRunning', order: 'ascending'}">
         <el-table-column
           fixed
           label="Name"
           prop="sink"
-          sortable
-          width="250">
+          sortable>
           <template slot-scope="scope">
             <a :href="`/sinks/${scope.row.cluster.name}/${scope.row.ns.namespace}/${scope.row.sink}`">
               <el-button type="text" @click.native.prevent="showDetails(scope.row.id)">{{ scope.row.sink }}</el-button>
@@ -30,6 +29,24 @@
                 disable-transitions>
                 {{scope.row.status.numRunning}}/{{scope.row.status.numInstances}}
             </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column
+          label="Read/Written">
+          <template slot-scope="scope">
+            {{scope.row.status.instances.reduce((r, d) => r + d.status.numReadFromPulsar, 0)}}/{{scope.row.status.instances.reduce((r, d) => r + d.status.numWrittenToSink, 0)}}
+          </template>
+        </el-table-column>
+        <el-table-column
+          label="Restarts">
+          <template slot-scope="scope">
+            {{scope.row.status.instances.reduce((r, d) => r + d.status.numRestarts, 0)}}
+          </template>
+        </el-table-column>
+        <el-table-column
+          label="Last received">
+          <template slot-scope="scope">
+            {{new Date(scope.row.status.instances.reduce((r, d) => Math.max(r, d.status.lastReceivedTime), 0)).toLocaleDateString('en-us', { month:"short", day:"numeric", hour:"numeric", minute:"numeric", second:"numeric"})}}
           </template>
         </el-table-column>
         <el-table-column

--- a/pages/topics/_cluster/_persistent/_tenant/_namespace/_topic/_id.vue
+++ b/pages/topics/_cluster/_persistent/_tenant/_namespace/_topic/_id.vue
@@ -137,6 +137,9 @@
           </el-button>
           <el-dropdown-menu slot="dropdown">
             <el-dropdown-item command="peekMessages">Peek messages</el-dropdown-item>
+            <el-dropdown-item command="getLastCommitMessage">Get last commit msg</el-dropdown-item>
+            <el-dropdown-item command="getPublishedMessageJustAfter">Get published msg just after a timestamp</el-dropdown-item>
+            <el-dropdown-item command="resetSubscription">Reset subscription</el-dropdown-item>
           </el-dropdown-menu>
         </el-dropdown>
         <el-button @click="reload()">Reload</el-button>
@@ -151,7 +154,7 @@
       </el-alert>
     </div>
 
-    <el-dialog title="Peek messages" :visible.sync="peekMessagesVisible" fullscreen>
+    <el-dialog title="Peek messages" :visible.sync="peekMessagesVisible">
       <el-form ref="peekMsgForm" :model="peekMessagesInfo" :rules="peekMsgRules" label-width="200px">
         <el-form-item label="Subscription" prop="subscription">
           <el-select v-model="peekMessagesInfo.subscription" placeholder="Please select a subscription">
@@ -164,6 +167,79 @@
         <el-form-item>
           <el-button type="primary" @click="peekMessages('peekMsgForm')">Peek messages</el-button>
           <el-button @click="peekMessagesVisible = false">Close</el-button>
+        </el-form-item>
+      </el-form>
+      <div>
+        <el-table
+          v-if="lastMessages.length > 0"
+          :data="lastMessages"
+          style="width: 100%"
+          height="65vh">
+          <el-table-column
+            sortable
+            width="300"
+            prop="publishTime"
+            label="Publish Time">
+          </el-table-column>
+          <el-table-column
+            prop="text"
+            label="Message as text">
+          </el-table-column>
+          
+        </el-table>
+      </div>
+    </el-dialog>
+    
+    <el-dialog title="Last commit message" :visible.sync="lastCommitMessagesVisible">
+      <div>
+        <div v-if="lastCommitMessage">
+            <span>{{lastCommitMessage}}</span>
+        </div>
+        <br />
+        <el-button @click="lastCommitMessagesVisible = false">Close</el-button>
+      </div>
+    </el-dialog>
+    
+    <el-dialog title="Published message just after timestamp" :visible.sync="publishedMessageJustAfterTimestampVisible">
+      <el-form ref="publishedMsgJustAfterForm" :model="publishedMsgJustAfterInfo" :rules="publishedMsgJustAfterRules" label-width="200px">
+        <el-form-item label="Timestamp" prop="timestamp">
+          <el-date-picker
+            v-model="publishedMsgJustAfterInfo.timestamp"
+            type="datetime"
+            placeholder="Pick a Date"
+            format="yyyy/MM/DD hh:mm:ss"
+          />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="getPublishedMessageJustAfter('publishedMsgJustAfterForm')">Get message</el-button>
+          <el-button @click="publishedMessageJustAfterTimestampVisible = false">Close</el-button>
+        </el-form-item>
+      </el-form>
+      <div>
+        <div v-if="publishedMessageJustAfterTimestamp">
+            <span>{{publishedMessageJustAfterTimestamp}}</span>
+        </div>
+      </div>
+    </el-dialog>
+    
+    <el-dialog title="Reset subscription" :visible.sync="resetSubscriptionVisible">
+      <el-form ref="resetSubscriptionForm" :model="resetSubscriptionInfo" :rules="resetSubscriptionRules" label-width="200px">
+        <el-form-item label="Subscription" prop="subscription">
+          <el-select v-model="resetSubscriptionInfo.subscription" placeholder="Please select a subscription">
+            <el-option v-for="sub in subscriptions" :key="sub.name" :label="sub.name" :value="sub.name"></el-option>
+          </el-select>
+        </el-form-item>
+        <el-form-item label="Timestamp" prop="timestamp">
+          <el-date-picker
+            v-model="resetSubscriptionInfo.timestamp"
+            type="datetime"
+            placeholder="Pick a Date"
+            format="yyyy/MM/DD hh:mm:ss"
+          />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="resetSubscription('resetSubscriptionForm')">Reset subscription</el-button>
+          <el-button @click="resetSubscriptionVisible = false">Close</el-button>
         </el-form-item>
       </el-form>
       <div>
@@ -229,7 +305,29 @@ export default {
             }
           }
         ]
-      }
+      },
+      lastCommitMessage: '',
+      lastCommitMessagesVisible: false,
+      publishedMsgJustAfterInfo: {
+        timestamp: new Date()
+      },
+      publishedMsgJustAfterRules: {
+        timestamp: [
+          { required: true, message: 'Please select a timestamp', trigger: 'change' }
+        ]
+      },
+      publishedMessageJustAfterTimestamp: '',
+      publishedMessageJustAfterTimestampVisible: false,
+      resetSubscriptionInfo: {
+        timestamp: new Date(),
+        subscription: ''
+      },
+      resetSubscriptionRules: {
+        subscription: [
+          { required: true, message: 'Please select a subscription', trigger: 'change' }
+        ]
+      },
+      resetSubscriptionVisible: false
     }
   },
 
@@ -304,7 +402,7 @@ export default {
         {
           cluster: cluster,
           name: this.$route.params.tenant + '/' + this.$route.params.namespace + '/' + this.$route.params.topic, 
-          persistent: this.$route.params.persistent, 
+          persistent: this.$route.params.persistent == 'persistent', 
           stats: await this.$pulsar.fetchTopicStats(this.$route.params.persistent + '/' + topicName, cluster)
         }
       ])
@@ -318,6 +416,16 @@ export default {
       switch (action) {
         case 'peekMessages':
           this.peekMessagesVisible = true
+          break
+        case 'getLastCommitMessage':
+          this.getLastCommitMessage()
+          this.lastCommitMessagesVisible = true
+          break
+        case 'getPublishedMessageJustAfter':
+          this.publishedMessageJustAfterTimestampVisible = true
+          break
+        case 'resetSubscription':
+          this.resetSubscriptionVisible = true
           break
       }
     },
@@ -350,6 +458,43 @@ export default {
           return false
         }
       })
+    },
+    
+    async getLastCommitMessage() {
+      this.loading = true
+      this.lastCommitMessage = await this.$pulsar.getLastCommitMessages((this.currentTopic.persistent ? 'persistent' : 'non-persistent') + '/' + this.currentTopic.name, this.currentTopic.cluster)
+      this.loading = false
+    },
+    
+    getPublishedMessageJustAfter(formName) {
+      const topicName = (this.currentTopic.persistent ? 'persistent' : 'non-persistent') + '/' + this.currentTopic.name
+      this.$pulsar.getMessagesPublishedJustAfterTimestamp(topicName, Math.floor(new Date(this.publishedMsgJustAfterInfo.timestamp).getTime() / 1000), this.currentTopic.cluster)
+        .then((resp) => {
+          console.log(resp)
+          this.publishedMessageJustAfterTimestamp = resp
+        })
+        .catch ((err) => {
+          this.$message({
+            type: 'error',
+            message: 'Error: ' + err
+          })
+        })
+    },
+    
+    resetSubscription(formName) {
+      const topicName = (this.currentTopic.persistent ? 'persistent' : 'non-persistent') + '/' + this.currentTopic.name
+      this.$pulsar.resetSubscription(topicName, this.resetSubscriptionInfo.subscription, Math.floor(new Date(this.resetSubscriptionInfo.timestamp).getTime() / 1000), this.currentTopic.cluster)
+        .then((resp) => {
+          this.$message({
+            message: resp.data
+          })
+        })
+        .catch ((err) => {
+          this.$message({
+            type: 'error',
+            message: 'Error: ' + err
+          })
+        })
     }
   },
 

--- a/pages/topics/index.vue
+++ b/pages/topics/index.vue
@@ -249,7 +249,7 @@ export default {
 
     showDetails(id) {
       const topic = this.topics[id]
-      this.$router.push({ path: '/topics/' + topic.cluster.name + '/' + topic.persistent + '/' + topic.name })
+      this.$router.push({ path: '/topics/' + topic.cluster.name + '/' + (topic.persistent ? 'persistent' : 'non-persistent') + '/' + topic.name })
     },
 
     async reload() {

--- a/pages/topics/index.vue
+++ b/pages/topics/index.vue
@@ -20,11 +20,14 @@
           sortable
           width="300">
           <template slot-scope="scope">
-            <el-button type="text" @click.native.prevent="showDetails(scope.row.id)">{{ scope.row.name }}</el-button>
+            <a :href="`/topics/${scope.row.cluster.name}/${scope.row.persistent ? 'persistent' : 'non-persistent'}/${scope.row.name}`">
+              <el-button type="text" @click.native.prevent="showDetails(scope.row.id)">{{ scope.row.name }}</el-button>
+            </a>
           </template>
         </el-table-column>
         <el-table-column
           label="Persistent"
+          sortable
           width="100">
           <template slot-scope="scope">
             <i class="el-icon-check" v-if="scope.row.persistent"></i>
@@ -33,26 +36,31 @@
         <el-table-column
           prop="stats.msgRateIn"
           label="Msg/s in"
+          sortable
           :formatter="cellFormatFloat">
         </el-table-column>
         <el-table-column
           prop="stats.msgRateOut"
           label="Msg/s out"
+          sortable
           :formatter="cellFormatFloat">
         </el-table-column>
         <el-table-column
           prop="stats.msgThroughputIn"
           label="Byte/s in"
+          sortable
           :formatter="cellFormatFloat">
         </el-table-column>
         <el-table-column
           prop="stats.msgThroughputOut"
           label="Byte/s out"
+          sortable
           :formatter="cellFormatFloat">
         </el-table-column>
         <el-table-column
           prop="stats.storageSize"
           label="Storage size"
+          sortable
           :formatter="cellFormatBytesToBestUnit">
         </el-table-column>
         <el-table-column
@@ -240,8 +248,8 @@ export default {
     },
 
     showDetails(id) {
-      this.setTopic(id)
-      this.$router.push({ path: '/topics/' + id })
+      const topic = this.topics[id]
+      this.$router.push({ path: '/topics/' + topic.cluster.name + '/' + topic.persistent + '/' + topic.name })
     },
 
     async reload() {

--- a/pages/workers/index.vue
+++ b/pages/workers/index.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="dataview">
+    <breadcrumb :items="[ { path: '/clusters', label: cluster ? 'Cluster ' + cluster.name : 'All clusters' }, { label: 'Workers' } ]" />
+    <loading v-if="loading" />
+    <div v-else-if="workers.length > 0">
+      <el-table
+        :data="workers"
+        style="width: 100%">
+        <el-table-column
+          prop="cluster.name"
+          label="Cluster name"
+          sortable>
+        </el-table-column>
+        <el-table-column
+          prop="worker.workerId"
+          label="Worker">
+        </el-table-column>
+        <el-table-column
+          prop="worker.workerHostname"
+          label="Hostname">
+        </el-table-column>
+      </el-table>
+    </div>
+    <div v-else>
+      <el-alert
+        title="Bad news"
+        type="warning"
+        description="Cannot get any information about workers. Maybe you haven't defined any connections or do not have any worker."
+        show-icon>
+      </el-alert>
+    </div>
+    <div class="button-bar">
+      <el-button @click="reload()">Reload</el-button>
+    </div>
+  </div>
+</template>
+
+<script>
+import loading from '@/components/loading'
+import breadcrumb from '@/components/breadcrumb'
+import { mapState, mapActions } from 'vuex'
+
+export default {
+  name: 'workers',
+
+  layout: 'dataview',
+
+  components: {
+    loading, breadcrumb
+  },
+
+  data() {
+    return {
+      workers: [],
+      loading: false
+    }
+  },
+
+  computed: mapState('context', ['cluster']),
+
+  mounted() {
+    this.reload()
+  },
+
+  methods: {
+    async reload() {
+      this.loading = true
+      let connections = []
+
+      if (this.cluster) {
+        connections.push(this.cluster.connection)
+      }
+      else {
+        await this.$store.dispatch('connections/fetchConnections')
+        connections = this.$store.state.connections.connections
+      }
+
+      const clusters = await this.$pulsar.fetchClusters(connections)
+      this.workers = await this.$pulsar.fetchWorkers(clusters)
+
+      this.loading = false
+    }
+  },
+
+  head() {
+    return {
+      title: 'pulsar-express - brokers'
+    }
+  }
+}
+</script>

--- a/services/pulsar-api.js
+++ b/services/pulsar-api.js
@@ -337,4 +337,8 @@ export default $axios => ({
 
     return workers
   },
+  
+  async rebalanceWorkers(cluster) {
+    return await $axios.$put('/api/admin/v2/worker/rebalance?' + getServiceParams(cluster.connection))
+  },
 })

--- a/services/pulsar-api.js
+++ b/services/pulsar-api.js
@@ -167,7 +167,7 @@ export default $axios => ({
 
     for (const ns of namespaces) {
       try {
-        const result = await $axios.$get('/api/admin/v3/sinks/' + ns.namespace + '?' + getServiceParams(ns.cluster.connection))
+        const result = await $axios.$get('/api/admin/v3/sinks/' + ns.namespace + '?' + getServiceParams(ns.cluster.connection, true))
         sinks = sinks.concat(result.map(sink => ({ cluster: ns.cluster, ns: ns, sink })))
       }
       catch (err) {
@@ -185,7 +185,7 @@ export default $axios => ({
   },
 
   async fetchSink(sink, cluster, ns) {
-    return await $axios.$get('/api/admin/v3/sinks/' + ns.namespace + '/' + sink + '?' + getServiceParams(cluster.connection))
+    return await $axios.$get('/api/admin/v3/sinks/' + ns.namespace + '/' + sink + '?' + getServiceParams(cluster.connection, true))
   },
 
   async fetchSourcesNS(namespaces) {
@@ -193,7 +193,7 @@ export default $axios => ({
 
     for (const ns of namespaces) {
       try {
-        const result = await $axios.$get('/api/admin/v3/sources/' + ns.namespace + '?' + getServiceParams(ns.cluster.connection))
+        const result = await $axios.$get('/api/admin/v3/sources/' + ns.namespace + '?' + getServiceParams(ns.cluster.connection, true))
         sources = sources.concat(result.map(source => ({ cluster: ns.cluster,ns: ns, source })))
       }
       catch (err) {
@@ -212,7 +212,7 @@ export default $axios => ({
   },
 
   async fetchSource(source, cluster, ns) {
-    return await $axios.$get('/api/admin/v3/sources/' + ns.namespace + '/' + source + '?' + getServiceParams(cluster.connection))
+    return await $axios.$get('/api/admin/v3/sources/' + ns.namespace + '/' + source + '?' + getServiceParams(cluster.connection, true))
   },
 
   deleteTopic(topicName, cluster) {

--- a/services/pulsar-api.js
+++ b/services/pulsar-api.js
@@ -187,6 +187,14 @@ export default $axios => ({
   async fetchSink(sink, cluster, ns) {
     return await $axios.$get('/api/admin/v3/sinks/' + ns.namespace + '/' + sink + '?' + getServiceParams(cluster.connection, true))
   },
+  
+  async fetchSinkStatus(sink, cluster, ns) {
+    return await $axios.$get('/api/admin/v3/sinks/' + ns.namespace + '/' + sink + '/status?' + getServiceParams(cluster.connection, true))
+  },
+  
+  async startStopSinkInstances(action, sink, cluster, ns) {
+    return await $axios.$post('/api/admin/v3/sinks/' + ns.namespace + '/' + sink + '/' + action + '?' + getServiceParams(cluster.connection, true))
+  },
 
   async fetchSourcesNS(namespaces) {
     let sources = []

--- a/services/pulsar-api.js
+++ b/services/pulsar-api.js
@@ -321,4 +321,20 @@ export default $axios => ({
         brokerServiceUrlTls: cluster.brokerServiceUrlTls
       })
   },
+  
+  async fetchWorkers(clusters) {
+    let workers = []
+
+    for (const cluster of clusters) {
+      try {
+        const result = await $axios.$get('/api/admin/v2/worker/cluster?' + getServiceParams(cluster.connection))
+        workers = workers.concat(result.map(worker => ({ cluster, worker })))
+      }
+      catch (err) {
+        console.error(err)
+      }
+    }
+
+    return workers
+  },
 })

--- a/services/pulsar-api.js
+++ b/services/pulsar-api.js
@@ -232,7 +232,33 @@ export default $axios => ({
   },
 
   peekMessages(topicName, subName, count, cluster) {
-    return $axios.get('/api/admin/v2/' + topicName + '/subscription/' + subName + '/position/' + count + '?' + getServiceParams(cluster.connection))
+    return $axios.get('/api/admin/v2/' + topicName + '/subscription/' + encodeURIComponent(encodeURIComponent(subName)) + '/position/' + count + '?' + getServiceParams(cluster.connection))
+  },
+  
+  async getLastCommitMessages(topicName, cluster) {
+    const lastCommitMessage = await $axios.$get('/api/admin/v2/' + topicName + '/lastMessageId?' + getServiceParams(cluster.connection))
+    if (lastCommitMessage) {
+        return {
+            ...lastCommitMessage,
+            payload: await $axios.$get('/api/admin/v2/' + topicName + '/ledger/' + lastCommitMessage.ledgerId + '/entry/' + lastCommitMessage.entryId + '?' + getServiceParams(cluster.connection))
+        }
+    }
+    return null;
+  },
+  
+  async getMessagesPublishedJustAfterTimestamp(topicName, timestamp, cluster) {
+    const publishedMessage = await $axios.$get('/api/admin/v2/' + topicName + '/messageid/' + timestamp + '?' + getServiceParams(cluster.connection))
+    if (publishedMessage) {
+        return {
+            ...publishedMessage, 
+            payload: await $axios.$get('/api/admin/v2/' + topicName + '/ledger/' + publishedMessage.ledgerId + '/entry/' + publishedMessage.entryId + '?' + getServiceParams(cluster.connection))
+        }
+    }
+    return null;
+  },
+  
+  async resetSubscription(topicName, subName, timestamp, cluster) {
+    return await $axios.$post('/api/admin/v2/' + topicName + '/subscription/' + encodeURIComponent(encodeURIComponent(subName)) + '/resetcursor/' + timestamp + '?' + getServiceParams(cluster.connection))
   },
 
   async fetchBrokers(clusters) {

--- a/store/context.js
+++ b/store/context.js
@@ -5,7 +5,9 @@ export const state = () => ({
   namespaces: null,
   function: null,
   functions: null,
-  cluster: null
+  cluster: null,
+  sink: null,
+  sinks: null
 })
 
 export const mutations = {


### PR DESCRIPTION
This pull request allow topic/function/sink detail page to be open independently, so people can share url or open the detail of a topic/function/sink in a new tab to work with multiple items at the same time.

This pull request also add pagination feature to the topic page (I have to temporarily disable the sort feature because it does not work properly with pagination).

Add the worker management feature.

Add instances management to sink detail page.

And some more....