### PR TITLE
Add delete function/sink, optimize display of long topic/function/sink name, and some features...

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,3 +253,7 @@ For Docker:
 ## Misc
 
 Icons: https://icones8.fr/
+
+## Credit
+
+Pulsar Express is a single only tool which is using daily to manage and maintain a Pulsar cluster of over ten nodes in production environment at https://doopage.com.

--- a/pages/brokers/index.vue
+++ b/pages/brokers/index.vue
@@ -110,7 +110,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - brokers'
+      title: 'Brokers - Pulsar Express'
     }
   }
 }

--- a/pages/clusters/index.vue
+++ b/pages/clusters/index.vue
@@ -230,7 +230,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - clusters'
+      title: 'Clusters - Pulsar Express'
     }
   }
 }

--- a/pages/connections.vue
+++ b/pages/connections.vue
@@ -159,7 +159,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - connections'
+      title: 'Connections - Pulsar Express'
     }
   }
 }

--- a/pages/functions/_cluster/_tenant/_namespace/_id.vue
+++ b/pages/functions/_cluster/_tenant/_namespace/_id.vue
@@ -121,6 +121,7 @@
         <el-button @click="reload()">Reload</el-button>
         <el-button type="success" @click="startAllInstances()">Start all instances</el-button>
         <el-button type="warning" @click="stopAllInstances()">Stop all instances</el-button>
+        <el-button type="danger" @click="deleteFunction()">Delete</el-button>
       </div>
     </div>
     <div v-else>
@@ -255,6 +256,22 @@ export default {
           this.$message({
             type: 'error',
             message: 'Start error: ' + err
+          })
+        })
+    },
+    
+    deleteFunction() {
+      this.$pulsar.deleteFunction(this.fullname, this.currentFunction.cluster)
+        .then (resp => {
+          this.$message({
+            type: 'success',
+            message: 'Deleted'
+          })
+        })
+        .catch (err => {
+          this.$message({
+            type: 'error',
+            message: 'Delete error: ' + err
           })
         })
     }

--- a/pages/functions/_cluster/_tenant/_namespace/_id.vue
+++ b/pages/functions/_cluster/_tenant/_namespace/_id.vue
@@ -279,7 +279,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - function'
+      title: 'Function ' + this.$route.params.tenant + '/' + this.$route.params.namespace + '/' + this.$route.params.id + ' - Pulsar Express'
     }
   }
 }

--- a/pages/functions/index.vue
+++ b/pages/functions/index.vue
@@ -15,8 +15,9 @@
           width="200">
           <template slot-scope="scope">
             <a :href="`/functions/${scope.row.cluster.name}/${scope.row.infos.tenant}/${scope.row.infos.namespace}/${scope.row.infos.name}`">
-              <el-button type="text" @click.native.prevent="showDetails(scope.row.id)">
-                {{scope.row.infos.tenant}}/{{scope.row.infos.namespace}}/{{scope.row.infos.name}}
+              <el-button type="text" @click.native.prevent="showDetails(scope.row.id)" style="text-align: left">
+                <p style="text-align: left; font-size: small; color: darkgray; margin-bottom: 4px">{{scope.row.infos.tenant}}/{{scope.row.infos.namespace}}/</p>
+                {{scope.row.infos.name}}
               </el-button>
             </a>
           </template>
@@ -66,33 +67,9 @@
           </template>
         </el-table-column>
         <el-table-column
-          label="Class name">
-          <template slot-scope="scope">
-            {{shortClassName(scope.row.infos.className)}}
-          </template>
-        </el-table-column>
-        <el-table-column
-          label="Input topics">
-          <template slot-scope="scope">
-            <span v-for="(input,key) in scope.row.infos.inputSpecs" :key="key">
-              {{getSimpleTopicName(key)}}<br/>
-            </span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          prop="infos.output"
-          label="Output topic"
-          :formatter="cellFormatSimpleTopicName">
-        </el-table-column>
-        <el-table-column
-          prop="infos.logTopic"
-          label="Log topic"
-          :formatter="cellFormatSimpleTopicName">
-        </el-table-column>
-        <el-table-column
           fixed="right"
           label="Actions"
-          width="120">
+          width="200">
           <template slot-scope="scope">
             <el-button
               @click.native.prevent="showDetails(scope.row.id)"

--- a/pages/functions/index.vue
+++ b/pages/functions/index.vue
@@ -100,6 +100,12 @@
               size="mini">
               Details
             </el-button>
+            <el-button
+              @click.native.prevent="deleteFunction(scope.row.id)"
+              type="danger" plain round
+              size="mini">
+              Delete
+            </el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -172,6 +178,24 @@ export default {
     showDetails(id) {
       const func = this.functions[id]
       this.$router.push({ path: '/functions/' + func.cluster.name + '/' + func.infos.tenant + '/' + func.infos.namespace + '/' + func.infos.name })
+    },
+    
+    deleteFunction(id) {
+      const func = this.functions[id]
+      this.$pulsar.deleteFunction(func.fullname, func.currentFunction.cluster)
+        .then (resp => {
+          this.$message({
+            type: 'success',
+            message: 'Deleted'
+          })
+          this.reload()
+        })
+        .catch (err => {
+          this.$message({
+            type: 'error',
+            message: 'Delete error: ' + err
+          })
+        })
     },
 
     async reload() {

--- a/pages/functions/index.vue
+++ b/pages/functions/index.vue
@@ -234,7 +234,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - functions'
+      title: 'Functions - Pulsar Express'
     }
   }
 }

--- a/pages/namespaces/index.vue
+++ b/pages/namespaces/index.vue
@@ -212,7 +212,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - namespaces'
+      title: 'Namespaces - Pulsar Express'
     }
   }
 }

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -73,7 +73,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - overview'
+      title: 'Overview - Pulsar Express'
     }
   }
 }

--- a/pages/sinks/_cluster/_tenant/_namespace/_id.vue
+++ b/pages/sinks/_cluster/_tenant/_namespace/_id.vue
@@ -210,7 +210,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - sink'
+      title: 'Sink ' + this.$route.params.tenant + '/' + this.$route.params.namespace + '/' + this.$route.params.id + ' - Pulsar Express'
     }
   }
 }

--- a/pages/sinks/_cluster/_tenant/_namespace/_id.vue
+++ b/pages/sinks/_cluster/_tenant/_namespace/_id.vue
@@ -7,10 +7,6 @@
       <h3>Properties</h3>
 
       <propertyview :props="policies"></propertyview>
-
-      <div class="button-bar">
-        <el-button @click="reload()">Reload</el-button>
-      </div>
       
       <h3>Instances</h3>
       <div v-if="instances.length > 0">
@@ -69,6 +65,7 @@
         <el-button @click="reload()">Reload</el-button>
         <el-button type="success" @click="startAllInstances()">Start all instances</el-button>
         <el-button type="warning" @click="stopAllInstances()">Stop all instances</el-button>
+        <el-button type="danger" @click="deleteSink()">Delete</el-button>
       </div>
     </div>
     <div v-else>
@@ -164,6 +161,22 @@ export default {
           this.$message({
             type: 'error',
             message: 'Start error: ' + err
+          })
+        })
+    },
+    
+    deleteSink() {
+      this.$pulsar.deleteSink(this.currentSink.sink, this.currentSink.cluster, this.currentSink.ns)
+        .then (resp => {
+          this.$message({
+            type: 'success',
+            message: 'Deleted'
+          })
+        })
+        .catch (err => {
+          this.$message({
+            type: 'error',
+            message: 'Delete error: ' + err
           })
         })
     },

--- a/pages/sinks/index.vue
+++ b/pages/sinks/index.vue
@@ -14,7 +14,10 @@
           sortable>
           <template slot-scope="scope">
             <a :href="`/sinks/${scope.row.cluster.name}/${scope.row.ns.namespace}/${scope.row.sink}`">
-              <el-button type="text" @click.native.prevent="showDetails(scope.row.id)">{{ scope.row.sink }}</el-button>
+              <el-button type="text" @click.native.prevent="showDetails(scope.row.id)" style="text-align: left">
+                <p style="text-align: left; font-size: small; color: darkgray; margin-bottom: 4px">{{scope.row.ns.namespace}}/</p>
+                {{ scope.row.sink }}
+              </el-button>
             </a>
           </template>
         </el-table-column>

--- a/pages/sinks/index.vue
+++ b/pages/sinks/index.vue
@@ -180,7 +180,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - sinks'
+      title: 'Sinks - Pulsar Express'
     }
   }
 }

--- a/pages/sinks/index.vue
+++ b/pages/sinks/index.vue
@@ -64,6 +64,12 @@
               size="mini">
               Details
             </el-button>
+            <el-button
+              @click.native.prevent="deleteSink(scope.row.id)"
+              type="danger" plain round
+              size="mini">
+              Delete
+            </el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -149,6 +155,24 @@ export default {
       const sink = this.sinks[id]
       this.$router.push({ path: '/sinks/' + sink.cluster.name + '/' + sink.ns.namespace + '/' + sink.sink })
     },
+    
+    deleteSink(id) {
+      const sink = this.sinks[id]
+      this.$pulsar.deleteSink(sink.sink, sink.cluster, sink.ns)
+        .then (resp => {
+          this.$message({
+            type: 'success',
+            message: 'Deleted'
+          })
+          this.reload()
+        })
+        .catch (err => {
+          this.$message({
+            type: 'error',
+            message: 'Delete error: ' + err
+          })
+        })
+    }
   },
 
   head() {

--- a/pages/sources/index.vue
+++ b/pages/sources/index.vue
@@ -115,7 +115,7 @@ export default {
 
   head() {
     return {
-      title: "pulsar-express - sources",
+      title: "Sources - Pulsar Express",
     };
   },
 };

--- a/pages/tenants/index.vue
+++ b/pages/tenants/index.vue
@@ -193,7 +193,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - tenants'
+      title: 'Tenants - Pulsar Express'
     }
   }
 }

--- a/pages/topics/_cluster/_persistent/_tenant/_namespace/_topic/_id.vue
+++ b/pages/topics/_cluster/_persistent/_tenant/_namespace/_topic/_id.vue
@@ -474,7 +474,6 @@ export default {
       const topicName = (this.currentTopic.persistent ? 'persistent' : 'non-persistent') + '/' + this.currentTopic.name
       this.$pulsar.getMessagesPublishedJustAfterTimestamp(topicName, Math.floor(new Date(this.publishedMsgJustAfterInfo.timestamp).getTime() / 1000), this.currentTopic.cluster)
         .then((resp) => {
-          console.log(resp)
           this.publishedMessageJustAfterTimestamp = resp
         })
         .catch ((err) => {

--- a/pages/topics/_cluster/_persistent/_tenant/_namespace/_topic/_id.vue
+++ b/pages/topics/_cluster/_persistent/_tenant/_namespace/_topic/_id.vue
@@ -137,8 +137,8 @@
           </el-button>
           <el-dropdown-menu slot="dropdown">
             <el-dropdown-item command="peekMessages">Peek messages</el-dropdown-item>
-            <el-dropdown-item command="getLastCommitMessage">Get last commit msg</el-dropdown-item>
-            <el-dropdown-item command="getPublishedMessageJustAfter">Get published msg just after a timestamp</el-dropdown-item>
+            <el-dropdown-item command="getLastCommitMessage">Get last commit message</el-dropdown-item>
+            <el-dropdown-item command="getPublishedMessageJustAfter">Get published message just after a timestamp</el-dropdown-item>
             <el-dropdown-item command="resetSubscription">Reset subscription</el-dropdown-item>
           </el-dropdown-menu>
         </el-dropdown>

--- a/pages/topics/_cluster/_persistent/_tenant/_namespace/_topic/_id.vue
+++ b/pages/topics/_cluster/_persistent/_tenant/_namespace/_topic/_id.vue
@@ -521,7 +521,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - topic'
+      title: 'Topic ' + this.$route.params.tenant + '/' + this.$route.params.namespace + '/' + this.$route.params.topic + ' - Pulsar Express'
     }
   }
 }

--- a/pages/topics/_cluster/_persistent/_tenant/_namespace/_topic/_id.vue
+++ b/pages/topics/_cluster/_persistent/_tenant/_namespace/_topic/_id.vue
@@ -140,6 +140,7 @@
             <el-dropdown-item command="getLastCommitMessage">Get last commit message</el-dropdown-item>
             <el-dropdown-item command="getPublishedMessageJustAfter">Get published message just after a timestamp</el-dropdown-item>
             <el-dropdown-item command="resetSubscription">Reset subscription</el-dropdown-item>
+            <el-dropdown-item command="createMissedPartitions">Create missed partitions</el-dropdown-item>
           </el-dropdown-menu>
         </el-dropdown>
         <el-button @click="reload()">Reload</el-button>
@@ -427,6 +428,9 @@ export default {
         case 'resetSubscription':
           this.resetSubscriptionVisible = true
           break
+        case 'createMissedPartitions':
+          this.createMissedPartitions()
+          break
       }
     },
 
@@ -486,7 +490,25 @@ export default {
       this.$pulsar.resetSubscription(topicName, this.resetSubscriptionInfo.subscription, Math.floor(new Date(this.resetSubscriptionInfo.timestamp).getTime() / 1000), this.currentTopic.cluster)
         .then((resp) => {
           this.$message({
-            message: resp.data
+            type: 'success',
+            message: 'Reset the subscription successfully!'
+          })
+        })
+        .catch ((err) => {
+          this.$message({
+            type: 'error',
+            message: 'Error: ' + err
+          })
+        })
+    },
+    
+    createMissedPartitions() {
+      const topicName = (this.currentTopic.persistent ? 'persistent' : 'non-persistent') + '/' + this.currentTopic.name
+      this.$pulsar.createMissedPartitions(topicName, this.currentTopic.cluster)
+        .then((resp) => {
+          this.$message({
+            type: 'success',
+            message: 'Created missed partitions!'
           })
         })
         .catch ((err) => {

--- a/pages/topics/index.vue
+++ b/pages/topics/index.vue
@@ -19,7 +19,10 @@
           width="300">
           <template slot-scope="scope">
             <a :href="`/topics/${scope.row.cluster.name}/${scope.row.persistent ? 'persistent' : 'non-persistent'}/${scope.row.name}`">
-              <el-button type="text" @click.native.prevent="showDetails(scope.row.id)">{{ scope.row.name }}</el-button>
+              <el-button type="text" @click.native.prevent="showDetails(scope.row.id)" style="text-align: left">
+                <p style="font-size: small; color: darkgray; margin-bottom: 4px">{{scope.row.name.substring(0, scope.row.name.lastIndexOf('/'))}}/</p>
+                {{ shortenTopicName(scope.row.name) }}
+              </el-button>
             </a>
           </template>
         </el-table-column>
@@ -334,6 +337,14 @@ export default {
     handlePageChange(val) {
         this.page = val;
     },
+    
+    shortenTopicName(fullTopicName) {
+        if (fullTopicName.match(/-partition-[0-9]+$/)) {
+            var topicName = fullTopicName.substring(fullTopicName.lastIndexOf('/') + 1)
+            return topicName.substring(0, topicName.lastIndexOf('-partition-')) + ' (' + topicName.substring(topicName.lastIndexOf('-partition-') + 11) + ')'
+        }
+        return fullTopicName.substring(fullTopicName.lastIndexOf('/') + 1)
+    }
   },
 
   head() {

--- a/pages/topics/index.vue
+++ b/pages/topics/index.vue
@@ -349,7 +349,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - topics'
+      title: 'Topics - Pulsar Express'
     }
   }
 }

--- a/pages/workers/index.vue
+++ b/pages/workers/index.vue
@@ -84,7 +84,7 @@ export default {
 
   head() {
     return {
-      title: 'pulsar-express - brokers'
+      title: 'Brokers - Pulsar Express'
     }
   }
 }

--- a/services/pulsar-api.js
+++ b/services/pulsar-api.js
@@ -268,6 +268,10 @@ export default $axios => ({
   async resetSubscription(topicName, subName, timestamp, cluster) {
     return await $axios.$post('/api/admin/v2/' + topicName + '/subscription/' + encodeURIComponent(encodeURIComponent(subName)) + '/resetcursor/' + timestamp + '?' + getServiceParams(cluster.connection))
   },
+  
+  async createMissedPartitions(topicName, cluster) {
+    return await $axios.$post('/api/admin/v2/' + topicName + '/createMissedPartitions?' + getServiceParams(cluster.connection))
+  },
 
   async fetchBrokers(clusters) {
     let brokers = []

--- a/services/pulsar-api.js
+++ b/services/pulsar-api.js
@@ -39,6 +39,10 @@ export default $axios => ({
   async fetchTopicStats(topic, cluster) {
     return await $axios.$get('/api/admin/v2/' + topic + '/stats?' + getServiceParams(cluster.connection))
   },
+  
+  async deleteFunction(fctName, cluster) {
+    return await $axios.$delete('/api/admin/v3/functions/' + fctName + '?' + getServiceParams(cluster.connection, true))
+  },
 
   async fetchNamespace(ns, cluster) {
     return await $axios.$get('/api/admin/v2/namespaces/' + ns + '?' + getServiceParams(cluster.connection))

--- a/services/pulsar-api.js
+++ b/services/pulsar-api.js
@@ -199,6 +199,10 @@ export default $axios => ({
   async startStopSinkInstances(action, sink, cluster, ns) {
     return await $axios.$post('/api/admin/v3/sinks/' + ns.namespace + '/' + sink + '/' + action + '?' + getServiceParams(cluster.connection, true))
   },
+  
+  async deleteSink(sink, cluster, ns) {
+    return await $axios.$delete('/api/admin/v3/sinks/' + ns.namespace + '/' + sink + '?' + getServiceParams(cluster.connection, true))
+  },
 
   async fetchSourcesNS(namespaces) {
     let sources = []


### PR DESCRIPTION
This pull request optimize the title of detail page to include topic name, function name or sink name in the title so the page can be saved to bookmark bar or so on and easily be recognized to reopen by user who just need to focus on managing some topics/functions/sinks.

This one also add some features like delete function/sink, create missed partitions of a topic.

Optimize look and feel of topic/sink/function name to separate tenant and namespace to another line to shorten topic/sink/function name. This also shorten the partition name format of a topic.