### PR TITLE
Speeding up function/sink/topic index pages

### DIFF
--- a/pages/topics/index.vue
+++ b/pages/topics/index.vue
@@ -87,7 +87,8 @@
               layout="prev, pager, next"
               @current-change="handlePageChange"
               :page-size="pageSize"
-              :total="total">
+              :total="total"
+              :current-page="page">
           </el-pagination>
       </div>
     </div>
@@ -295,29 +296,7 @@ export default {
       
       const topicRefs = await this.$pulsar.fetchTopics(this.clusters)
 
-      this.topics = []
-
-      const topicWithStats = (ref, stats) => {
-        return {
-          cluster: ref.cluster,
-          name: ref.topic.substring(ref.topic.indexOf('://') + 3), 
-          persistent: ref.topic.startsWith('persistent'), 
-          stats: stats
-        }
-      }
-
-      this.topics = await Promise.all(
-        topicRefs.map(ref =>
-          this.$pulsar.fetchTopicStats(ref.topic.replace(":/",""), ref.cluster)
-            .then((topicStats) => topicWithStats(ref, topicStats))
-            .catch((e) => {
-              console.error(e);
-              return topicWithStats(ref, undefined);
-            })
-        )
-      )
-
-      this.topics = this.topics.map((t, id) => ({ ...t, id }))
+      this.topics = topicRefs.map((ref) => ({ topic: ref.topic, name: ref.topic.substring(ref.topic.indexOf('://') + 3), cluster: ref.cluster, persistent: ref.topic.startsWith('persistent') }))
 
       /*for (const ref of topicRefs) {
         const topicStats = await this.$pulsar.fetchTopicStats(ref.topic.replace(":/",""), ref.cluster)
@@ -332,10 +311,50 @@ export default {
       this.setTopics(this.topics)
 
       this.loading = false
+      
+      this.fetchTopicStats()
+    },
+    
+    async fetchTopicStats() {
+      this.loading = true
+      var filteredTopics = this.topics.filter(data => !this.search || data.name.toLowerCase().includes(this.search.toLowerCase()));
+      filteredTopics = filteredTopics.slice(this.pageSize * this.page - this.pageSize, this.pageSize * this.page)
+    
+      const topicWithStats = (ref, stats) => {
+        return {
+          ...ref, 
+          stats: stats
+        }
+      }
+      
+      filteredTopics = await Promise.all(
+        filteredTopics.map(ref =>
+          this.$pulsar.fetchTopicStats(ref.topic.replace(":/",""), ref.cluster)
+            .then((topicStats) => topicWithStats(ref, topicStats))
+            .catch((e) => {
+              console.error(e);
+              return topicWithStats(ref, undefined);
+            })
+        )
+      )
+      
+      for(const ref of filteredTopics) {
+        for(var i=0; i < this.topics.length; i++) {
+            if (this.topics[i].topic == ref.topic) {
+                this.topics[i].stats = ref.stats
+                break
+            }
+        }
+      }
+      
+      this.setTopics(this.topics)
+      
+      this.loading = false
     },
     
     handlePageChange(val) {
         this.page = val;
+        this.fetchTopicStats();
     },
     
     shortenTopicName(fullTopicName) {


### PR DESCRIPTION
This pull request speed up the index page especially for large number of functions/sink/topic. Ten thousands of topics now can be load easily due to better paging.

This pull request also optimize that the failure to fetch info of a sink/function won't causes index page broken.